### PR TITLE
Add support for Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ PATH_STUMPWM_GNOME = $(PREFIX)/bin/stumpwm-gnome
 PATH_STUMPWM_GNOME_DESKTOP = $(PREFIX)/share/applications/stumpwm-gnome.desktop
 PATH_STUMPWM_GNOME_SESSION = $(PREFIX)/share/gnome-session/sessions/stumpwm-gnome.session
 PATH_STUMPWM_GNOME_XSESSION = $(PREFIX)/share/xsessions/stumpwm-gnome.desktop
+PATH_STUMPWM_GNOME_SYSTEMD = $(PREFIX)/lib/systemd/user/gnome-session-x11@stumpwm-gnome.target
+
+ifeq (,$(FLAVOR))
+	SESSION_DIR=session
+else
+	SESSION_DIR=session.$(FLAVOR)
+endif
 
 #
 # Targets
@@ -20,10 +27,13 @@ all:
 
 
 install:
-	$(INSTALL) -m0644 -D session/stumpwm-gnome-xsession.desktop $(PATH_STUMPWM_GNOME_XSESSION)
-	$(INSTALL) -m0644 -D session/stumpwm-gnome.desktop $(PATH_STUMPWM_GNOME_DESKTOP)
-	$(INSTALL) -m0644 -D session/stumpwm-gnome.session $(PATH_STUMPWM_GNOME_SESSION)
-	$(INSTALL) -m0755 -D session/stumpwm-gnome $(PATH_STUMPWM_GNOME)
+	$(INSTALL) -m0644 -D $(SESSION_DIR)/stumpwm-gnome-xsession.desktop $(PATH_STUMPWM_GNOME_XSESSION)
+	$(INSTALL) -m0644 -D $(SESSION_DIR)/stumpwm-gnome.desktop $(PATH_STUMPWM_GNOME_DESKTOP)
+	$(INSTALL) -m0644 -D $(SESSION_DIR)/stumpwm-gnome.session $(PATH_STUMPWM_GNOME_SESSION)
+	$(INSTALL) -m0755 -D $(SESSION_DIR)/stumpwm-gnome $(PATH_STUMPWM_GNOME)
+ifneq (,$(wildcard $(SESSION_DIR)/stumpwm-gnome.target))
+	$(INSTALL) -m0644 -D $(SESSION_DIR)/stumpwm-gnome.target $(PATH_STUMPWM_GNOME_SYSTEMD)
+endif
 
 
 uninstall:
@@ -31,6 +41,7 @@ uninstall:
 	rm -f $(PATH_STUMPWM_GNOME_DESKTOP)
 	rm -f $(PATH_STUMPWM_GNOME_SESSION)
 	rm -f $(PATH_STUMPWM_GNOME_XSESSION)
+	rm -f $(PATH_STUMPWM_GNOME_SYSTEMD)
 
 
 .PHONY: all install uninstall

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@
 
 Allows you to use stumpwm with GNOME 3 Session infrastructure on Arch Linux.
 
+For ubuntu, you have to set the FLAVOR environment variable first:
+`export FLAVOR=ubuntu`. If you are using `sudo` don't forget to add
+`-E` argument to pass environment variables. e.g. `sudo -E make
+install` or in one command: `sudo make install FLAVOR=ubuntu`.

--- a/session.ubuntu/stumpwm-gnome
+++ b/session.ubuntu/stumpwm-gnome
@@ -1,0 +1,1 @@
+../session/stumpwm-gnome

--- a/session.ubuntu/stumpwm-gnome-xsession.desktop
+++ b/session.ubuntu/stumpwm-gnome-xsession.desktop
@@ -1,0 +1,10 @@
+# -*- mode: conf -*-
+
+[Desktop Entry]
+Comment=GNOME session management + stumpwm
+Exec=gnome-session --session=stumpwm-gnome --systemd
+Name=GNOME + stumpwm
+TryExec=gnome-session
+Type=XSession
+# Without DesktopNames entry gnome input dialogs may not work
+DesktopNames=stumpwm-gnome

--- a/session.ubuntu/stumpwm-gnome.desktop
+++ b/session.ubuntu/stumpwm-gnome.desktop
@@ -1,0 +1,1 @@
+../session/stumpwm-gnome.desktop

--- a/session.ubuntu/stumpwm-gnome.session
+++ b/session.ubuntu/stumpwm-gnome.session
@@ -1,0 +1,5 @@
+# -*- mode: conf -*-
+
+[GNOME Session]
+Name=stumpwm-gnome
+RequiredComponents=stumpwm-gnome;org.gnome.Shell;org.gnome.SettingsDaemon.A11ySettings;org.gnome.SettingsDaemon.Color;org.gnome.SettingsDaemon.Datetime;org.gnome.SettingsDaemon.Housekeeping;org.gnome.SettingsDaemon.Keyboard;org.gnome.SettingsDaemon.MediaKeys;org.gnome.SettingsDaemon.Power;org.gnome.SettingsDaemon.PrintNotifications;org.gnome.SettingsDaemon.Rfkill;org.gnome.SettingsDaemon.ScreensaverProxy;org.gnome.SettingsDaemon.Sharing;org.gnome.SettingsDaemon.Smartcard;org.gnome.SettingsDaemon.Sound;org.gnome.SettingsDaemon.Wacom;org.gnome.SettingsDaemon.XSettings;

--- a/session.ubuntu/stumpwm-gnome.target
+++ b/session.ubuntu/stumpwm-gnome.target
@@ -1,0 +1,31 @@
+[Unit]
+Description=StumpWM GNOME Session
+OnFailure=gnome-session-failed.target
+OnFailureJobMode=replace
+DefaultDependencies=no
+RefuseManualStart=no
+
+Conflicts=shutdown.target gnome-session-shutdown.target
+PartOf=graphical-session.target
+
+# Pull in all X11-specific services the session might depend on
+Requires=gnome-session-x11-services.target
+
+BindsTo=gnome-session@.target
+After=gnome-session@.target
+
+BindsTo=gnome-session.target
+After=gnome-session.target
+
+Requires=indicators-pre.target
+
+# here we list the indicators that we want to load
+Wants=indicator-application.service
+Wants=indicator-bluetooth.service
+Wants=indicator-datetime.service
+Wants=indicator-keyboard.service
+Wants=indicator-messages.service
+Wants=indicator-power.service
+Wants=indicator-printers.service
+Wants=indicator-session.service
+Wants=indicator-sound.service


### PR DESCRIPTION
Ubuntu uses systemd session management, so we have to add a systemd
target file to enable required gnome components.

This commit is adapted from the "gnome-session-flashback" package on
Ubuntu repositories and tested on Ubuntu 20.04 (beta).